### PR TITLE
allow loading secrets from separate files

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ filters = ["1080p"]
 download_dir = "/downloads/my_folder"
 ```
 
+The password and telegram bot token can optionally be loaded from separate files by specifying `password_file`/`bot_token_file` instead.
 
 ### Docker
 It's also possible to run the docker container directly or using `docker-compose.yml`.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::fs::read_to_string;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Config {
@@ -13,10 +14,44 @@ pub struct Persistence {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(try_from = "RawTransmission")]
 pub struct Transmission {
     pub url: String,
     pub username: String,
     pub password: String,
+}
+
+impl TryFrom<RawTransmission> for Transmission {
+    type Error = std::io::Error;
+
+    fn try_from(value: RawTransmission) -> Result<Self, Self::Error> {
+        let password = match value.password {
+            TransmissionPassword::Raw { password } => password,
+            TransmissionPassword::File { password_file } => {
+                read_to_string(password_file)?.trim().to_string()
+            }
+        };
+        Ok(Transmission {
+            url: value.url,
+            username: value.username,
+            password,
+        })
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct RawTransmission {
+    pub url: String,
+    pub username: String,
+    #[serde(flatten)]
+    pub password: TransmissionPassword,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+pub enum TransmissionPassword {
+    Raw { password: String },
+    File { password_file: String },
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -28,11 +63,43 @@ pub struct RssList {
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Notification {
-    pub telegram: Option<TelegramNotification>
+    pub telegram: Option<TelegramNotification>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(try_from = "RawTelegramNotification")]
 pub struct TelegramNotification {
     pub bot_token: String,
     pub chat_id: i64,
+}
+
+impl TryFrom<RawTelegramNotification> for TelegramNotification {
+    type Error = std::io::Error;
+
+    fn try_from(value: RawTelegramNotification) -> Result<Self, Self::Error> {
+        let bot_token = match value.bot_token {
+            TelegramToken::Raw { bot_token } => bot_token,
+            TelegramToken::File { bot_token_file } => {
+                read_to_string(bot_token_file)?.trim().to_string()
+            }
+        };
+        Ok(TelegramNotification {
+            bot_token,
+            chat_id: value.chat_id,
+        })
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct RawTelegramNotification {
+    #[serde(flatten)]
+    pub bot_token: TelegramToken,
+    pub chat_id: i64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+pub enum TelegramToken {
+    Raw { bot_token: String },
+    File { bot_token_file: String },
 }


### PR DESCRIPTION
Allows loading password and telegram token from separate files instead of writing them in the main config.

This can be done by setting `password_file`/`bot_token_file` instead of `password`/`bot_token`.

Motivation here is using it in NixOS, where the config files are generally stored in a world-readable place (or even in public git repos) with secrets loaded from separate files that can be stored encrypted.