### PR TITLE
handle torrents linked as enclosure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1160,9 +1160,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
  "value-bag",
@@ -2151,7 +2151,9 @@ name = "transmission-rss"
 version = "0.3.0"
 dependencies = [
  "clap",
+ "env_logger",
  "httpmock",
+ "log",
  "openssl",
  "reqwest",
  "rss",
@@ -2211,9 +2213,9 @@ dependencies = [
 
 [[package]]
 name = "value-bag"
-version = "1.0.0-alpha.8"
+version = "1.0.0-alpha.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79923f7731dc61ebfba3633098bf3ac533bbd35ccd8c57e7088d9a5eebe0263f"
+checksum = "2209b78d1249f7e6f3293657c9779fe31ced465df091bbd433a1cf88e916ec55"
 dependencies = [
  "ctor",
  "version_check",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ sled = "0.34.7"
 clap = { version = "3.1.13", features = ["derive"] }
 openssl = { version = "0.10", features = ["vendored"] }
 serde_json = "1.0"
+log = "0.4.17"
+env_logger = "0.9.0"
 
 [dev-dependencies]
 tokio-test = "0.4.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
-use std::fs;
 use clap::Parser;
-use transmission_rss::config::{Config};
+use std::fs;
+use transmission_rss::config::Config;
 use transmission_rss::rss::process_feed;
 
 /// Parse args
@@ -14,7 +14,7 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-
+    env_logger::init();
     // Read env
     let args = Args::parse();
 

--- a/src/rss.rs
+++ b/src/rss.rs
@@ -1,5 +1,6 @@
 use crate::config::{Config, RssList};
 use crate::notification::notify_all;
+use log::info;
 use rss::{Channel, Item};
 use std::error::Error;
 use transmission_rpc::types::{BasicAuth, RpcResponse, TorrentAddArgs, TorrentAdded};
@@ -46,6 +47,16 @@ pub async fn process_feed(item: RssList, cfg: Config) -> Result<i32, Box<dyn Err
                     if it.title().unwrap_or_default().contains(&filter) {
                         found = true;
                     }
+                }
+
+                if !found {
+                    info!(
+                        "Skipping {} as it doesn't match any filter",
+                        it.title
+                            .as_deref()
+                            .or(it.link.as_deref())
+                            .unwrap_or_default()
+                    )
                 }
 
                 return found;

--- a/src/rss.rs
+++ b/src/rss.rs
@@ -30,7 +30,7 @@ pub async fn process_feed(item: RssList, cfg: Config) -> Result<i32, Box<dyn Err
         .into_iter()
         .filter(|it| {
             // Check if item is already on db
-            let db_found = match db.get(it.link().unwrap()) {
+            let db_found = match db.get(get_link(it)) {
                 Ok(val) => val,
                 Err(_) => None,
             };
@@ -69,10 +69,10 @@ pub async fn process_feed(item: RssList, cfg: Config) -> Result<i32, Box<dyn Err
     let mut count = 0;
     for result in results {
         let title = result.title().unwrap_or_default();
-        let link = result.link().unwrap_or_default().to_string();
+        let link = get_link(result);
         // Add the torrent into transmission
         let add: TorrentAddArgs = TorrentAddArgs {
-            filename: Some(link.clone()),
+            filename: Some(link.to_string()),
             download_dir: Some(item.download_dir.clone()),
             ..TorrentAddArgs::default()
         };
@@ -85,7 +85,7 @@ pub async fn process_feed(item: RssList, cfg: Config) -> Result<i32, Box<dyn Err
             notify_all(cfg.clone(), format!("Downloading: {}", title)).await;
 
             // Persist the item into the database
-            match db.insert(&link, b"") {
+            match db.insert(link, b"") {
                 Ok(_) => println!("{:?} saved into db!", &link),
                 Err(err) => println!("Failed to save {:?} into db: {:?}", link, err),
             }
@@ -96,4 +96,11 @@ pub async fn process_feed(item: RssList, cfg: Config) -> Result<i32, Box<dyn Err
     db.flush()?;
 
     Ok(count)
+}
+
+fn get_link(item: &Item) -> &str {
+    match item.enclosure() {
+        Some(enclosure) if enclosure.mime_type() == "application/x-bittorrent" => enclosure.url(),
+        _ => item.link().unwrap_or_default(),
+    }
 }


### PR DESCRIPTION
Correctly handle feeds where the torrent link is linked as `<enclosure type="application/x-bittorrent">` instead of in the `<link>` such as https://archlinux.org/feeds/releases/

Also includes adding `env-logger` used to figure out why the feed wasn't working previously.